### PR TITLE
Обновления для сборки с Qt 5.14 в linux

### DIFF
--- a/G2G/G2G.pro
+++ b/G2G/G2G.pro
@@ -42,6 +42,7 @@ gcc* {
 
 linux {
     DEFINES += linux
+    LIBS += -ltbb # Why?????
 }
 
 DEFINES += "BUILD_DATE=\"\\\"$$_DATE_\\\"\""

--- a/G2G/datastream.h
+++ b/G2G/datastream.h
@@ -4,6 +4,7 @@
 #include <QDataStream>
 #include <type_traits>
 
+#if QT_DEPRECATED_SINCE(5, 14)
 template <typename E, typename = std::enable_if_t<std::is_enum_v<E>>>
 inline QDataStream& operator>>(QDataStream& s, E& e)
 {
@@ -19,5 +20,6 @@ inline QDataStream& operator<<(QDataStream& s, E e)
     s << static_cast<qint32>(e);
     return s;
 }
+#endif
 
 #endif // DATASTREAM_H

--- a/G2G/forms/profileform.ui
+++ b/G2G/forms/profileform.ui
@@ -364,7 +364,7 @@
   <customwidget>
    <class>ToolName</class>
    <extends>QWidget</extends>
-   <header>toolname.h</header>
+   <header>forms/toolname.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/G2G/forms/toolname.cpp
+++ b/G2G/forms/toolname.cpp
@@ -12,7 +12,7 @@ ToolName::ToolName(QWidget* parent)
     lblName = new QLabel(this);
     lblName->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
     l->addWidget(lblName);
-    l->setMargin(0);
+    l->setContentsMargins(0, 0, 0, 0);
     l->setSpacing(6);
     l->setStretch(1, 1);
 }

--- a/G2G/mainwindow.cpp
+++ b/G2G/mainwindow.cpp
@@ -613,7 +613,11 @@ void MainWindow::printDialog()
         pPrinter->setResolution(4800);
 
         QPainter painter(pPrinter);
+#if QT_DEPRECATED_SINCE(5, 14)
         painter.setRenderHint(QPainter::HighQualityAntialiasing);
+#else
+        painter.setRenderHint(QPainter::Antialiasing);
+#endif
         painter.setTransform(QTransform().scale(1.0, -1.0));
         painter.translate(0, -(pPrinter->resolution() / 25.4) * size.height());
         scene->render(&painter,

--- a/gcode/gccreator.cpp
+++ b/gcode/gccreator.cpp
@@ -539,7 +539,7 @@ bool Creator::pointOnPolygon(const QLineF& l2, const Path& path, IntPoint* ret)
         const IntPoint& pt1 = path[(i + 1) % cnt];
         const IntPoint& pt2 = path[i];
         QLineF l1(toQPointF(pt1), toQPointF(pt2));
-        if (QLineF::BoundedIntersection == l1.intersect(l2, &p)) {
+        if (QLineF::BoundedIntersection == l1.intersects(l2, &p)) {
             if (ret)
                 *ret = toIntPoint(p);
             return true;

--- a/graphicsview/graphicsview.cpp
+++ b/graphicsview/graphicsview.cpp
@@ -30,7 +30,11 @@ GraphicsView::GraphicsView(QWidget* parent)
         exit(1);
     }
     setCacheMode(/*CacheBackground*/ CacheNone);
-    setOptimizationFlags(DontSavePainterState | DontClipPainter | DontAdjustForAntialiasing);
+    setOptimizationFlags(DontSavePainterState
+#if QT_DEPRECATED_SINCE(5, 14)
+                         | DontClipPainter
+#endif
+                         | DontAdjustForAntialiasing);
     setViewportUpdateMode(FullViewportUpdate /*SmartViewportUpdate*/ /*NoViewportUpdate*/);
     setDragMode(RubberBandDrag);
     setInteractive(true);
@@ -264,11 +268,15 @@ double GraphicsView::getScale()
 void GraphicsView::wheelEvent(QWheelEvent* event)
 {
     const int scbarScale = 3;
+
+    const auto delta = event->angleDelta().y();
+    const auto pos = event->position().toPoint();
+
     switch (event->modifiers()) {
     case Qt::ControlModifier:
-        if (abs(event->delta()) == 120) {
+        if (abs(delta) == 120) {
             setInteractive(false);
-            if (event->delta() > 0)
+            if (delta > 0)
                 zoomIn();
             else
                 zoomOut();
@@ -279,9 +287,9 @@ void GraphicsView::wheelEvent(QWheelEvent* event)
         if (!event->angleDelta().x()) {
             auto scrollBar = QAbstractScrollArea::horizontalScrollBar();
             if (Settings::guiSmoothScSh()) {
-                anim(scrollBar, "value", scrollBar->value(), scrollBar->value() - scrollBar->pageStep() / (event->delta() > 0 ? scbarScale : -scbarScale));
+                anim(scrollBar, "value", scrollBar->value(), scrollBar->value() - scrollBar->pageStep() / (delta > 0 ? scbarScale : -scbarScale));
             } else {
-                scrollBar->setValue(scrollBar->value() - event->delta());
+                scrollBar->setValue(scrollBar->value() - delta);
             }
         }
         break;
@@ -289,9 +297,9 @@ void GraphicsView::wheelEvent(QWheelEvent* event)
         if (!event->angleDelta().x()) {
             auto scrollBar = QAbstractScrollArea::verticalScrollBar();
             if (Settings::guiSmoothScSh()) {
-                anim(scrollBar, "value", scrollBar->value(), scrollBar->value() - scrollBar->pageStep() / (event->delta() > 0 ? scbarScale : -scbarScale));
+                anim(scrollBar, "value", scrollBar->value(), scrollBar->value() - scrollBar->pageStep() / (delta > 0 ? scbarScale : -scbarScale));
             } else {
-                scrollBar->setValue(scrollBar->value() - event->delta());
+                scrollBar->setValue(scrollBar->value() - delta);
             }
         } else {
             //   QAbstractScrollArea::horizontalScrollBar()->setValue(QAbstractScrollArea::horizontalScrollBar()->value() - (event->delta()));
@@ -301,7 +309,7 @@ void GraphicsView::wheelEvent(QWheelEvent* event)
         //QGraphicsView::wheelEvent(event);
         return;
     }
-    mouseMove(mapToScene(event->pos()));
+    mouseMove(mapToScene(pos));
     event->accept();
     update();
 }


### PR DESCRIPTION
1. Отключены расширения из файла G2G/datastream.h если верисия Qt 5.14
2. Заменены устаревшие методы QWheelEvent::delta() и QWheelEvent::pos() на актуальные аналоги
3. Заменен устаревший метод QLineF::intersect() на QLineF::intersects()
4. Заменен устаревший метод QHBoxLayout::setMargin() на QHBoxLayout::setContentsMargins()
5. Заменен устаревший флаг HighQualityAntialiasing на Antialiasing
6. Убран устаревший флаг DontClipPainter для GraphicsView::setOptimizationFlags()
7. Усправлен отсутствующий отностиельный путь до файла toolname.h в файле G2G/forms/profileform.ui
8. Добавлена линковка с библиотекой libtbb для linux. (Почему?)