### PR TITLE
Починены ошибки при сборке в Qt<5.14

### DIFF
--- a/G2G/datastream.h
+++ b/G2G/datastream.h
@@ -4,7 +4,7 @@
 #include <QDataStream>
 #include <type_traits>
 
-#if QT_DEPRECATED_SINCE(5, 14)
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
 template <typename E, typename = std::enable_if_t<std::is_enum_v<E>>>
 inline QDataStream& operator>>(QDataStream& s, E& e)
 {

--- a/gcode/gccreator.cpp
+++ b/gcode/gccreator.cpp
@@ -539,7 +539,13 @@ bool Creator::pointOnPolygon(const QLineF& l2, const Path& path, IntPoint* ret)
         const IntPoint& pt1 = path[(i + 1) % cnt];
         const IntPoint& pt2 = path[i];
         QLineF l1(toQPointF(pt1), toQPointF(pt2));
-        if (QLineF::BoundedIntersection == l1.intersects(l2, &p)) {
+        if (QLineF::BoundedIntersection ==
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+                l1.intersect(l2, &p)
+#else
+                l1.intersects(l2, &p)
+#endif
+                ) {
             if (ret)
                 *ret = toIntPoint(p);
             return true;

--- a/graphicsview/graphicsview.cpp
+++ b/graphicsview/graphicsview.cpp
@@ -270,7 +270,11 @@ void GraphicsView::wheelEvent(QWheelEvent* event)
     const int scbarScale = 3;
 
     const auto delta = event->angleDelta().y();
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    const auto pos = event->pos();
+#else
     const auto pos = event->position().toPoint();
+#endif
 
     switch (event->modifiers()) {
     case Qt::ControlModifier:


### PR DESCRIPTION
Исправил сборку, как минимум с Qt 5.13 собирается и запускается.
Макрос QT_DEPRECATED_SINCE работает не так, как ожидалось, пришлось ввезти явную проверку версии Qt.