### PR TITLE
Fix spindle speed in GCode

### DIFF
--- a/plugins/gcode/gc_file.h
+++ b/plugins/gcode/gc_file.h
@@ -40,7 +40,7 @@ public:
         , toolType{newGcp.toolType()}
         , strFeed{u'F' + format(feedRate)}
         , strPlungeFeed{u'F' + format(plungeRate)}
-        , strSpindle{u'S' + format(plungeRate)}
+        , strSpindle{u'S' + format(spindleSpeed)}
         , gcp{std::move(newGcp)} {
         setSide(gcp.params[Params::FileSide]);
     }


### PR DESCRIPTION
Опечатка. В параметре M3 вместо скорости шпинделя выставлялась скорость врезания