### PR TITLE
Fix "G-Code Properties" form

### DIFF
--- a/plugins/gcode/gc_propertiesform.cpp
+++ b/plugins/gcode/gc_propertiesform.cpp
@@ -48,6 +48,12 @@ PropertiesForm::PropertiesForm(QWidget* parent)
     connect(ui->sbxStepsX, qOverload<int>(&QSpinBox::valueChanged), App::projectPtr(), &Project::setStepsX);
     connect(ui->sbxStepsY, qOverload<int>(&QSpinBox::valueChanged), App::projectPtr(), &Project::setStepsY);
 
+    connect(ui->dsbxSafeZ, &QDoubleSpinBox::valueChanged, App::projectPtr(), &Project::setSafeZ);
+    connect(ui->dsbxClearence, &QDoubleSpinBox::valueChanged, App::projectPtr(), &Project::setClearence);
+    connect(ui->dsbxPlunge, &QDoubleSpinBox::valueChanged, App::projectPtr(), &Project::setPlunge);
+    connect(ui->dsbxThickness, &QDoubleSpinBox::valueChanged, App::projectPtr(), &Project::setBoardThickness);
+    connect(ui->dsbxCopperThickness, &QDoubleSpinBox::valueChanged, App::projectPtr(), &Project::setCopperThickness);
+
     connect(ui->dsbxSafeZ, &QDoubleSpinBox::valueChanged, [this](double value) {
         ui->dsbxSafeZ->setValue(value);
         ui->dsbxSafeZ->setValue(value);
@@ -75,9 +81,6 @@ PropertiesForm::PropertiesForm(QWidget* parent)
     });
 
     ui->pbOk->setIcon(QIcon::fromTheme(u"dialog-ok-apply"_s));
-
-    if(parent != nullptr)
-        setWindowTitle(ui->label->text());
 
     for(auto* button: findChildren<QPushButton*>())
         button->setIconSize({16, 16});

--- a/plugins/gcode/gcodepropertiesform.ui
+++ b/plugins/gcode/gcodepropertiesform.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>G-Code Properties</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="leftMargin">
@@ -46,27 +46,6 @@
      <property name="midLineWidth">
       <number>0</number>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <property name="leftMargin">
-       <number>6</number>
-      </property>
-      <property name="topMargin">
-       <number>6</number>
-      </property>
-      <property name="rightMargin">
-       <number>6</number>
-      </property>
-      <property name="bottomMargin">
-       <number>6</number>
-      </property>
-      <item>
-       <widget class="QLabel" name="label">
-<property name="text">
-         <string>G-Code Properties</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
     </widget>
    </item>
    <item>

--- a/static_libs/common/depthform.cpp
+++ b/static_libs/common/depthform.cpp
@@ -63,6 +63,14 @@ DepthForm::~DepthForm() {
     settings.endGroup();
 }
 
+void DepthForm::showEvent(QShowEvent* event) {
+    if(rbCopper->isChecked())
+        dsbx->setValue(App::project().copperThickness());
+    else if(rbBoard->isChecked())
+        dsbx->setValue(App::project().boardThickness());
+    QWidget::showEvent(event);
+}
+
 double DepthForm::value() const { return dsbx->value(); }
 
 void DepthForm::setValue(double value) {

--- a/static_libs/common/depthform.h
+++ b/static_libs/common/depthform.h
@@ -26,6 +26,9 @@ public:
 signals:
     void valueChanged(double);
 
+protected:
+    void showEvent(QShowEvent* event) override;
+
 private:
     double value_{};
 


### PR DESCRIPTION
Значения из G-Code Properties не применялись потому что переменные не были привязаны к ui. Чуть обновил ui под общий стиль. Добавил showEvent для обновления параметров при открытии формы